### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -1,4 +1,6 @@
 name: "Main pipeline"
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/jmatiascabrera/devops-sandbox/security/code-scanning/13](https://github.com/jmatiascabrera/devops-sandbox/security/code-scanning/13)

To fix the problem, you should add a `permissions` block that explicitly restricts the GITHUB_TOKEN's permissions to the minimum required. Since all jobs seem to only check out code and use local actions (and do not, for example, push code or create releases), `contents: read` should suffice. This block should be placed at the root of the workflow YAML file, immediately under the `name` field and before the `on` field, so that it applies to all jobs by default.

**Steps:**
- Edit `.github/workflows/main-pipeline.yml`
- Insert
  ```yaml
  permissions:
    contents: read
  ```
  after `name: "Main pipeline"` and before `on:`.

No further imports, definitions, or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
